### PR TITLE
[doalerts] Add command line options

### DIFF
--- a/doalerts/.flake8
+++ b/doalerts/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+ignore = E501, W503

--- a/doalerts/Pipfile
+++ b/doalerts/Pipfile
@@ -1,0 +1,12 @@
+[[source]]
+name = "pypi"
+url = "https://pypi.org/simple"
+verify_ssl = true
+
+[dev-packages]
+
+[packages]
+requests = "*"
+
+[requires]
+python_version = "2.7"

--- a/doalerts/Pipfile
+++ b/doalerts/Pipfile
@@ -10,4 +10,4 @@ requests = "*"
 click = "*"
 
 [requires]
-python_version = "2.7"
+python_version = "3.6"

--- a/doalerts/Pipfile
+++ b/doalerts/Pipfile
@@ -5,6 +5,7 @@ verify_ssl = true
 
 [dev-packages]
 black = "*"
+flake8 = "*"
 
 [packages]
 requests = "*"

--- a/doalerts/Pipfile
+++ b/doalerts/Pipfile
@@ -4,6 +4,7 @@ url = "https://pypi.org/simple"
 verify_ssl = true
 
 [dev-packages]
+black = "*"
 
 [packages]
 requests = "*"
@@ -11,3 +12,6 @@ click = "*"
 
 [requires]
 python_version = "3.6"
+
+[pipenv]
+allow_prereleases = true

--- a/doalerts/Pipfile
+++ b/doalerts/Pipfile
@@ -7,6 +7,7 @@ verify_ssl = true
 
 [packages]
 requests = "*"
+click = "*"
 
 [requires]
 python_version = "2.7"

--- a/doalerts/Pipfile.lock
+++ b/doalerts/Pipfile.lock
@@ -1,11 +1,11 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "7ef2df7549e46a73c7a23cc9ac635a9d41208fc50148506c0fc3bf1645264ae1"
+            "sha256": "0619194f1015577df8ae518b023371de41f21d1cb86cd6e8506896a0130f43ae"
         },
         "pipfile-spec": 6,
         "requires": {
-            "python_version": "2.7"
+            "python_version": "3.6"
         },
         "sources": [
             {

--- a/doalerts/Pipfile.lock
+++ b/doalerts/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "9838c8bf3aa442453b393e09e534ba7e1666aab4da1b9b408ecdf3ae58ab273c"
+            "sha256": "7ef2df7549e46a73c7a23cc9ac635a9d41208fc50148506c0fc3bf1645264ae1"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -29,6 +29,14 @@
                 "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"
             ],
             "version": "==3.0.4"
+        },
+        "click": {
+            "hashes": [
+                "sha256:2335065e6395b9e67ca716de5f7526736bfa6ceead690adf616d925bdc622b13",
+                "sha256:5b94b49521f6456670fdb30cd82a4eca9412788a93fa6dd6df72c94d5a8ff2d7"
+            ],
+            "index": "pypi",
+            "version": "==7.0"
         },
         "idna": {
             "hashes": [

--- a/doalerts/Pipfile.lock
+++ b/doalerts/Pipfile.lock
@@ -1,0 +1,57 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "9838c8bf3aa442453b393e09e534ba7e1666aab4da1b9b408ecdf3ae58ab273c"
+        },
+        "pipfile-spec": 6,
+        "requires": {
+            "python_version": "2.7"
+        },
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {
+        "certifi": {
+            "hashes": [
+                "sha256:47f9c83ef4c0c621eaef743f133f09fa8a74a9b75f037e8624f83bd1b6626cb7",
+                "sha256:993f830721089fef441cdfeb4b2c8c9df86f0c63239f06bd025a76a7daddb033"
+            ],
+            "version": "==2018.11.29"
+        },
+        "chardet": {
+            "hashes": [
+                "sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae",
+                "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"
+            ],
+            "version": "==3.0.4"
+        },
+        "idna": {
+            "hashes": [
+                "sha256:c357b3f628cf53ae2c4c05627ecc484553142ca23264e593d327bcde5e9c3407",
+                "sha256:ea8b7f6188e6fa117537c3df7da9fc686d485087abf6ac197f9c46432f7e4a3c"
+            ],
+            "version": "==2.8"
+        },
+        "requests": {
+            "hashes": [
+                "sha256:502a824f31acdacb3a35b6690b5fbf0bc41d63a24a45c4004352b0242707598e",
+                "sha256:7bf2a778576d825600030a110f3c0e3e8edc51dfaafe1c146e39a2027784957b"
+            ],
+            "index": "pypi",
+            "version": "==2.21.0"
+        },
+        "urllib3": {
+            "hashes": [
+                "sha256:61bf29cada3fc2fbefad4fdf059ea4bd1b4a86d2b6d15e1c7c0b582b9752fe39",
+                "sha256:de9529817c93f27c8ccbfead6985011db27bd0ddfcdb2d86f3f663385c6a9c22"
+            ],
+            "version": "==1.24.1"
+        }
+    },
+    "develop": {}
+}

--- a/doalerts/Pipfile.lock
+++ b/doalerts/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "0619194f1015577df8ae518b023371de41f21d1cb86cd6e8506896a0130f43ae"
+            "sha256": "bd1aa977517216a9ffb8c4fd3d49002289d46e346788ea8417452f5870db1d26"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -61,5 +61,43 @@
             "version": "==1.24.1"
         }
     },
-    "develop": {}
+    "develop": {
+        "appdirs": {
+            "hashes": [
+                "sha256:9e5896d1372858f8dd3344faf4e5014d21849c756c8d5701f78f8a103b372d92",
+                "sha256:d8b24664561d0d34ddfaec54636d502d7cea6e29c3eaf68f3df6180863e2166e"
+            ],
+            "version": "==1.4.3"
+        },
+        "attrs": {
+            "hashes": [
+                "sha256:10cbf6e27dbce8c30807caf056c8eb50917e0eaafe86347671b57254006c3e69",
+                "sha256:ca4be454458f9dec299268d472aaa5a11f67a4ff70093396e1ceae9c76cf4bbb"
+            ],
+            "version": "==18.2.0"
+        },
+        "black": {
+            "hashes": [
+                "sha256:817243426042db1d36617910df579a54f1afd659adb96fc5032fcf4b36209739",
+                "sha256:e030a9a28f542debc08acceb273f228ac422798e5215ba2a791a6ddeaaca22a5"
+            ],
+            "index": "pypi",
+            "version": "==18.9b0"
+        },
+        "click": {
+            "hashes": [
+                "sha256:2335065e6395b9e67ca716de5f7526736bfa6ceead690adf616d925bdc622b13",
+                "sha256:5b94b49521f6456670fdb30cd82a4eca9412788a93fa6dd6df72c94d5a8ff2d7"
+            ],
+            "index": "pypi",
+            "version": "==7.0"
+        },
+        "toml": {
+            "hashes": [
+                "sha256:229f81c57791a41d65e399fc06bf0848bab550a9dfd5ed66df18ce5f05e73d5c",
+                "sha256:235682dd292d5899d361a811df37e04a8828a5b1da3115886b73cf81ebc9100e"
+            ],
+            "version": "==0.10.0"
+        }
+    }
 }

--- a/doalerts/Pipfile.lock
+++ b/doalerts/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "bd1aa977517216a9ffb8c4fd3d49002289d46e346788ea8417452f5870db1d26"
+            "sha256": "950f8c68a01e5364c8c3d03744832fba13b6b32fd6dbdb70f0134b4aa7ecb215"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -91,6 +91,35 @@
             ],
             "index": "pypi",
             "version": "==7.0"
+        },
+        "flake8": {
+            "hashes": [
+                "sha256:6a35f5b8761f45c5513e3405f110a86bea57982c3b75b766ce7b65217abe1670",
+                "sha256:c01f8a3963b3571a8e6bd7a4063359aff90749e160778e03817cd9b71c9e07d2"
+            ],
+            "index": "pypi",
+            "version": "==3.6.0"
+        },
+        "mccabe": {
+            "hashes": [
+                "sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42",
+                "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"
+            ],
+            "version": "==0.6.1"
+        },
+        "pycodestyle": {
+            "hashes": [
+                "sha256:cbc619d09254895b0d12c2c691e237b2e91e9b2ecf5e84c26b35400f93dcfb83",
+                "sha256:cbfca99bd594a10f674d0cd97a3d802a1fdef635d4361e1a2658de47ed261e3a"
+            ],
+            "version": "==2.4.0"
+        },
+        "pyflakes": {
+            "hashes": [
+                "sha256:9a7662ec724d0120012f6e29d6248ae3727d821bba522a0e6b356eff19126a49",
+                "sha256:f661252913bc1dbe7fcfcbf0af0db3f42ab65aabd1a6ca68fe5d466bace94dae"
+            ],
+            "version": "==2.0.0"
         },
         "toml": {
             "hashes": [

--- a/doalerts/generate_alerts.py
+++ b/doalerts/generate_alerts.py
@@ -27,15 +27,18 @@ def analyze(revision_data, weight_fn=None):
     weighted_sum = 0
     sum_of_weights = 0
     for i in range(num_revisions):
-        weighted_sum += sum(value * weights[i] for value in
-                            revision_data[i].values)
+        weighted_sum += sum(value * weights[i] for value in revision_data[i].values)
         sum_of_weights += weights[i] * len(revision_data[i].values)
     weighted_avg = weighted_sum / sum_of_weights if num_revisions > 0 else 0.0
 
     # now that we have a weighted average, we can calculate the variance of the
     # whole series
     all_data = [v for datum in revision_data for v in datum.values]
-    variance = (sum(pow(d-weighted_avg, 2) for d in all_data) / (len(all_data)-1)) if len(all_data) > 1 else 0.0
+    variance = (
+        (sum(pow(d - weighted_avg, 2) for d in all_data) / (len(all_data) - 1))
+        if len(all_data) > 1
+        else 0.0
+    )
 
     return {"avg": weighted_avg, "n": len(all_data), "variance": variance}
 
@@ -67,21 +70,22 @@ def calc_t(w1, w2, weight_fn=None):
 
     s1 = analyze(w1, weight_fn)
     s2 = analyze(w2, weight_fn)
-    delta_s = s2['avg'] - s1['avg']
+    delta_s = s2["avg"] - s1["avg"]
 
     if delta_s == 0:
         return 0
-    if s1['variance'] == 0 and s2['variance'] == 0:
-        return float('inf')
+    if s1["variance"] == 0 and s2["variance"] == 0:
+        return float("inf")
 
-    return delta_s / (((s1['variance'] / s1['n']) + (s2['variance'] / s2['n'])) ** 0.5)
+    return delta_s / (((s1["variance"] / s1["n"]) + (s2["variance"] / s2["n"])) ** 0.5)
 
 
 @functools.total_ordering
 class RevisionDatum(object):
-    '''
+    """
     This class represents a specific revision and the set of values for it
-    '''
+    """
+
     def __init__(self, push_timestamp, push_id, values):
 
         # Date code was pushed
@@ -107,15 +111,19 @@ class RevisionDatum(object):
         return self.push_timestamp < o.push_timestamp
 
     def __repr__(self):
-        values_str = '[ %s ]' % ', '.join(['%.3f' % value for value in
-                                           self.values])
-        return "<%s: %s, %s, %.3f, %s>" % (self.push_timestamp,
-                                           self.push_id, values_str,
-                                           self.t, self.change_detected)
+        values_str = "[ %s ]" % ", ".join(["%.3f" % value for value in self.values])
+        return "<%s: %s, %s, %.3f, %s>" % (
+            self.push_timestamp,
+            self.push_id,
+            values_str,
+            self.t,
+            self.change_detected,
+        )
 
 
-def detect_changes(data, min_back_window=12, max_back_window=24,
-                   fore_window=12, t_threshold=7):
+def detect_changes(
+    data, min_back_window=12, max_back_window=24, fore_window=12, t_threshold=7
+):
     # Use T-Tests
     # Analyze test data using T-Tests, comparing data[i-j:i] to data[i:i+k]
     data = sorted(data)
@@ -129,10 +137,14 @@ def detect_changes(data, min_back_window=12, max_back_window=24,
         jw = []
         di.amount_prev_data = 0
         prev_indice = i - 1
-        while di.amount_prev_data < max_back_window and prev_indice >= 0 and (
-                (i - prev_indice) <= min(max(last_seen_regression,
-                                             min_back_window),
-                                         max_back_window)):
+        while (
+            di.amount_prev_data < max_back_window
+            and prev_indice >= 0
+            and (
+                (i - prev_indice)
+                <= min(max(last_seen_regression, min_back_window), max_back_window)
+            )
+        ):
             jw.append(data[prev_indice])
             di.amount_prev_data += len(jw[-1].values)
             prev_indice -= 1
@@ -171,12 +183,12 @@ def detect_changes(data, min_back_window=12, max_back_window=24,
             continue
 
         # Check the adjacent points
-        prev = data[i-1]
+        prev = data[i - 1]
         if prev.t > di.t:
             continue
         # next may or may not exist if it's the last in the series
-        if (i+1) < len(data):
-            next = data[i+1]
+        if (i + 1) < len(data):
+            next = data[i + 1]
             if next.t > di.t:
                 continue
 

--- a/doalerts/perfherder_alerts.py
+++ b/doalerts/perfherder_alerts.py
@@ -8,23 +8,30 @@ import click
 from generate_alerts import RevisionDatum, detect_changes
 
 # constants in perfherder
-interval = 7776000 # 90 days
-interval = 31536000 # 1 year
-pgohash = 'f69e1b00908837bf0550250abb1645014317e8ec'
-thurl = 'https://treeherder.mozilla.org'
+interval = 7776000  # 90 days
+interval = 31536000  # 1 year
+pgohash = "f69e1b00908837bf0550250abb1645014317e8ec"
+thurl = "https://treeherder.mozilla.org"
 
 # data we can iterate through
-frameworks = [{'id': 1, 'name': 'talos'},
-              {'id': 10, 'name': 'raptor'},
-              {'id': 4, 'name': 'awsy'},
-              {'id': 11, 'name': 'js-bench'}]
-branches = ['mozilla-inbound', 'autoland', 'mozilla-central']
-platforms = ['windows10-64', 'windows10-64-qr',
-             'linux64', 'linux64-qr',
-             'osx-10-10',
-             'windows7-32',
-             'android-hw-p2-8-0-arm7-api-16', 'android-hw-p2-8-0-android-aarch64',
-             'android-hw-g5-7-0-arm7-api-16']
+frameworks = [
+    {"id": 1, "name": "talos"},
+    {"id": 10, "name": "raptor"},
+    {"id": 4, "name": "awsy"},
+    {"id": 11, "name": "js-bench"},
+]
+branches = ["mozilla-inbound", "autoland", "mozilla-central"]
+platforms = [
+    "windows10-64",
+    "windows10-64-qr",
+    "linux64",
+    "linux64-qr",
+    "osx-10-10",
+    "windows7-32",
+    "android-hw-p2-8-0-arm7-api-16",
+    "android-hw-p2-8-0-android-aarch64",
+    "android-hw-g5-7-0-arm7-api-16",
+]
 
 
 # given raw data from a given perfherder signature,
@@ -33,9 +40,9 @@ def parseSignatureData(payload):
     datum = {}
     for rev in payload:
         for item in payload[rev]:
-            timestamp = item['push_timestamp']
-            pushid = item['push_id']
-            value = item['value']
+            timestamp = item["push_timestamp"]
+            pushid = item["push_id"]
+            value = item["value"]
             key = "%s:%s" % (timestamp, pushid)
             if key not in datum.keys():
                 datum[key] = []
@@ -43,7 +50,7 @@ def parseSignatureData(payload):
 
     data = []
     for key in datum:
-        timestamp,pushid = key.split(':')
+        timestamp, pushid = key.split(":")
         values = datum[key]
         data.append([timestamp, pushid, values])
     return data
@@ -51,30 +58,39 @@ def parseSignatureData(payload):
 
 # useful for getting a given url from treeherder
 def getUrl(url, key):
-    if not os.path.exists('cache'):
-        os.makedirs('cache')
+    if not os.path.exists("cache"):
+        os.makedirs("cache")
 
-    keypath = os.path.join('cache', '%s.json' % key)
+    keypath = os.path.join("cache", "%s.json" % key)
     if os.path.exists(keypath):
-        with open(keypath, 'r') as f:
+        with open(keypath, "r") as f:
             return json.load(f)
 
-    headers = {'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_5)',
-               'accept-encoding':'json'}
+    headers = {
+        "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_5)",
+        "accept-encoding": "json",
+    }
     response = requests.get(url, headers=headers)
     data = response.json()
 
-    with open(keypath, 'wb') as f:
+    with open(keypath, "wb") as f:
         json.dump(data, f)
     return data
 
+
 def getFrameworkId(name):
-    retVal = [f['id'] for f in frameworks if f['name'] == name]
+    retVal = [f["id"] for f in frameworks if f["name"] == name]
     return retVal[0]
 
+
 def getSignatures(branch, framework, platform):
-    url = '%s/api/project/%s/performance/signatures/' % (thurl, branch)
-    url = '%s?framework=%s&interval=%s&platform=%s&subtests=1' % (url, framework, interval, platform)
+    url = "%s/api/project/%s/performance/signatures/" % (thurl, branch)
+    url = "%s?framework=%s&interval=%s&platform=%s&subtests=1" % (
+        url,
+        framework,
+        interval,
+        platform,
+    )
     key = "%s-%s-%s" % (branch, framework, platform)
     return getUrl(url, key)
 
@@ -82,19 +98,21 @@ def getSignatures(branch, framework, platform):
 def filterSignatureIds(signatures, testname, subtests):
     sig_ids = []
     for sig in signatures:
-        if signatures[sig]['suite'] == testname:
-            metric = 'geomean'
-            option = 'opt'
-            if signatures[sig]['option_collection_hash'] == pgohash:
-                option = 'pgo'
+        if signatures[sig]["suite"] == testname:
+            metric = "geomean"
+            option = "opt"
+            if signatures[sig]["option_collection_hash"] == pgohash:
+                option = "pgo"
 
             # we have a subtest
-            if 'test' in signatures[sig]:
-                metric = signatures[sig]['test'].split(testname)[-1].strip('-')
+            if "test" in signatures[sig]:
+                metric = signatures[sig]["test"].split(testname)[-1].strip("-")
                 if not subtests:
                     continue
 
-            sig_ids.append({'id': signatures[sig]['id'], 'metric': metric, 'option': option})
+            sig_ids.append(
+                {"id": signatures[sig]["id"], "metric": metric, "option": option}
+            )
     return sig_ids
 
 
@@ -102,14 +120,17 @@ def getTestNames(branch, framework, platform):
     signatures = getSignatures(branch, framework, platform)
     names = []
     for sig in signatures:
-        if signatures[sig]['suite'] not in names:
-            names.append(signatures[sig]['suite'])
+        if signatures[sig]["suite"] not in names:
+            names.append(signatures[sig]["suite"])
     return names
 
 
 def analyzeData(sig, branch, framework):
-    url = "https://treeherder.mozilla.org/api/project/%s/performance/data/?framework=%s&interval=%s&signature_id=%s"  % (branch, framework, interval, sig['id'])
-    key = "%s-%s-%s" % (branch, framework, sig['id'])
+    url = (
+        "https://treeherder.mozilla.org/api/project/%s/performance/data/?framework=%s&interval=%s&signature_id=%s"
+        % (branch, framework, interval, sig["id"])
+    )
+    key = "%s-%s-%s" % (branch, framework, sig["id"])
     payload = getUrl(url, key)
 
     runs = parseSignatureData(payload)
@@ -121,29 +142,56 @@ def analyzeData(sig, branch, framework):
 
 
 def filterUniqueAlerts(results):
-    filtered = [{'sig': {}, 'result': []},{'sig': {}, 'result': []}]
+    filtered = [{"sig": {}, "result": []}, {"sig": {}, "result": []}]
     # TODO: consider weekends or slow times for a longer window - 24 hours
     # TODO: sanity check no alerts are on the same 12 hour window (maybe within 100 pushids?)
     hours = 6
-    first = [datetime.datetime.fromtimestamp(float(x.push_timestamp)) for x in results[0]['result']]
-    second = [datetime.datetime.fromtimestamp(float(x.push_timestamp)) for x in results[1]['result']]
+    first = [
+        datetime.datetime.fromtimestamp(float(x.push_timestamp))
+        for x in results[0]["result"]
+    ]
+    second = [
+        datetime.datetime.fromtimestamp(float(x.push_timestamp))
+        for x in results[1]["result"]
+    ]
     f_matched = set()
     s_matched = set()
     for s in first:
-        f_matched.update([s for f in second if s < f + datetime.timedelta(hours=hours) and s > f - datetime.timedelta(hours=hours) and s not in list(f_matched)])
+        f_matched.update(
+            [
+                s
+                for f in second
+                if s < f + datetime.timedelta(hours=hours)
+                and s > f - datetime.timedelta(hours=hours)
+                and s not in list(f_matched)
+            ]
+        )
     for s in second:
-        s_matched.update([s for f in first if s < f + datetime.timedelta(hours=hours) and s > f - datetime.timedelta(hours=hours) and s not in list(s_matched)])
+        s_matched.update(
+            [
+                s
+                for f in first
+                if s < f + datetime.timedelta(hours=hours)
+                and s > f - datetime.timedelta(hours=hours)
+                and s not in list(s_matched)
+            ]
+        )
     sets = [list(set(first) - f_matched), list(set(second) - s_matched)]
 
-    for iter in [0,1]:
+    for iter in [0, 1]:
         for item in results[iter]:
-            remaining = [x for x in results[iter]['result'] if datetime.datetime.fromtimestamp(float(x.push_timestamp)) in sets[iter]]
+            remaining = [
+                x
+                for x in results[iter]["result"]
+                if datetime.datetime.fromtimestamp(float(x.push_timestamp))
+                in sets[iter]
+            ]
             if len(remaining) == 0:
                 continue
 
-            filtered[iter]['sig'] = results[iter]['sig']
-            filtered[iter]['result'] = remaining
-        if filtered[iter] == {'sig': {}, 'result': []}:
+            filtered[iter]["sig"] = results[iter]["sig"]
+            filtered[iter]["result"] = remaining
+        if filtered[iter] == {"sig": {}, "result": []}:
             filtered[iter] = None
     results = [x for x in filtered if x != None]
     return results
@@ -157,27 +205,42 @@ def analyzeTest(framework, branch, platform, testname, subtests):
     for sig in sig_ids:
         result = analyzeData(sig, branch, framework)
         if result:
-            results.append({'sig': sig, 'result': result})
+            results.append({"sig": sig, "result": result})
 
     if results == []:
         return
 
     if not subtests and len(results) == 2:
-       results = filterUniqueAlerts(results)
+        results = filterUniqueAlerts(results)
 
     for i in results:
-        print("%s: %s:%s (%s)" % (testname, i['sig']['option'], i['sig']['metric'], len(i['result'])))
-        for d in i['result']:
+        print(
+            "%s: %s:%s (%s)"
+            % (testname, i["sig"]["option"], i["sig"]["metric"], len(i["result"]))
+        )
+        for d in i["result"]:
             date = datetime.datetime.fromtimestamp(float(d.push_timestamp)).isoformat()
             print("%s (%s)" % (date, d.push_id))
         print("")
 
 
 @click.command()
-@click.option("--framework", "-f", required=True, type=click.Choice([f["name"] for f in frameworks]))
+@click.option(
+    "--framework",
+    "-f",
+    required=True,
+    type=click.Choice([f["name"] for f in frameworks]),
+)
 @click.option("--branch", "-b", required=True, type=click.Choice(branches))
-@click.option("--platform", "-p", "platforms", multiple=True, required=True, type=click.Choice(platforms))
-@click.option('--subtests/--no-subtests', default=False)
+@click.option(
+    "--platform",
+    "-p",
+    "platforms",
+    multiple=True,
+    required=True,
+    type=click.Choice(platforms),
+)
+@click.option("--subtests/--no-subtests", default=False)
 def cli(framework, branch, platforms, subtests):
     framework = getFrameworkId(framework)
 

--- a/doalerts/perfherder_alerts.py
+++ b/doalerts/perfherder_alerts.py
@@ -166,11 +166,11 @@ def analyzeTest(framework, branch, platform, testname, subtests):
        results = filterUniqueAlerts(results)
 
     for i in results:
-        print "%s: %s:%s (%s)" % (testname, i['sig']['option'], i['sig']['metric'], len(i['result']))
+        print("%s: %s:%s (%s)" % (testname, i['sig']['option'], i['sig']['metric'], len(i['result'])))
         for d in i['result']:
             date = datetime.datetime.fromtimestamp(float(d.push_timestamp)).isoformat()
-            print "%s (%s)" % (date, d.push_id)
-        print ""
+            print("%s (%s)" % (date, d.push_id))
+        print("")
 
 
 @click.command()
@@ -182,7 +182,7 @@ def cli(framework, branch, platforms, subtests):
     framework = getFrameworkId(framework)
 
     for platform in platforms:
-        print "-------- %s -------------" % platform
+        print("-------- %s -------------" % platform)
         testnames = getTestNames(branch, framework, platform)
 
         for testname in testnames:

--- a/doalerts/perfherder_alerts.py
+++ b/doalerts/perfherder_alerts.py
@@ -193,7 +193,7 @@ def filterUniqueAlerts(results):
             filtered[iter]["result"] = remaining
         if filtered[iter] == {"sig": {}, "result": []}:
             filtered[iter] = None
-    results = [x for x in filtered if x != None]
+    results = [x for x in filtered if x is not None]
     return results
 
 

--- a/doalerts/perfherder_alerts.py
+++ b/doalerts/perfherder_alerts.py
@@ -174,12 +174,12 @@ def analyzeTest(framework, branch, platform, testname, subtests):
 
 
 @click.command()
-def cli():
-    # variables
-    framework = getFrameworkId('raptor')
-    branch = 'mozilla-inbound'
-    platforms = ['linux64', 'windows7-32', 'windows10-64']
-    subtests = False
+@click.option("--framework", "-f", required=True, type=click.Choice([f["name"] for f in frameworks]))
+@click.option("--branch", "-b", required=True, type=click.Choice(branches))
+@click.option("--platform", "-p", "platforms", multiple=True, required=True, type=click.Choice(platforms))
+@click.option('--subtests/--no-subtests', default=False)
+def cli(framework, branch, platforms, subtests):
+    framework = getFrameworkId(framework)
 
     for platform in platforms:
         print "-------- %s -------------" % platform

--- a/doalerts/perfherder_alerts.py
+++ b/doalerts/perfherder_alerts.py
@@ -3,6 +3,8 @@ import requests
 import os
 import datetime
 
+import click
+
 from generate_alerts import RevisionDatum, detect_changes
 
 # constants in perfherder
@@ -171,7 +173,8 @@ def analyzeTest(framework, branch, platform, testname, subtests):
         print ""
 
 
-def main():
+@click.command()
+def cli():
     # variables
     framework = getFrameworkId('raptor')
     branch = 'mozilla-inbound'
@@ -187,4 +190,4 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    cli()

--- a/doalerts/perfherder_alerts.py
+++ b/doalerts/perfherder_alerts.py
@@ -157,35 +157,36 @@ def filterUniqueAlerts(results):
     f_matched = set()
     s_matched = set()
     for s in first:
-        f_matched.update(
-            [
-                s
-                for f in second
-                if s < f + datetime.timedelta(hours=hours)
+        f_list = list()
+        for f in second:
+            if (
+                s < f + datetime.timedelta(hours=hours)
                 and s > f - datetime.timedelta(hours=hours)
                 and s not in list(f_matched)
-            ]
-        )
+            ):
+                f_list.append(s)
+        f_matched.update(f_list)
     for s in second:
-        s_matched.update(
-            [
-                s
-                for f in first
-                if s < f + datetime.timedelta(hours=hours)
+        s_list = list()
+        for f in first:
+            if (
+                s < f + datetime.timedelta(hours=hours)
                 and s > f - datetime.timedelta(hours=hours)
                 and s not in list(s_matched)
-            ]
-        )
+            ):
+                s_list.append(s)
+        s_matched.update(s_list)
     sets = [list(set(first) - f_matched), list(set(second) - s_matched)]
 
     for iter in [0, 1]:
         for item in results[iter]:
-            remaining = [
-                x
-                for x in results[iter]["result"]
-                if datetime.datetime.fromtimestamp(float(x.push_timestamp))
-                in sets[iter]
-            ]
+            remaining = list()
+            for x in results[iter]["result"]:
+                if (
+                    datetime.datetime.fromtimestamp(float(x.push_timestamp))
+                    in sets[iter]
+                ):
+                    remaining.append(x)
             if len(remaining) == 0:
                 continue
 

--- a/doalerts/perfherder_alerts.py
+++ b/doalerts/perfherder_alerts.py
@@ -59,7 +59,7 @@ def getUrl(url, key):
 
     headers = {'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_5)',
                'accept-encoding':'json'}
-    response = requests.get(url, headers=headers, verify=False)
+    response = requests.get(url, headers=headers)
     data = response.json()
 
     with open(keypath, 'wb') as f:

--- a/doalerts/readme.md
+++ b/doalerts/readme.md
@@ -5,43 +5,40 @@ Some intended use cases:
 2) investigate the different between pgo and opt
 3) adjust alert parameters to determine if we get more/less alerts with different thresholds/parameters
 
-Usage:
+Installation:
+
 ```
-  python perfherder_alerts.py
+pipenv install
 ```
 
-Current output:
+Usage:
+
 ```
-  opt:ttfi                                            <- opt||pgo : <metric> 
-  <1545319998: 416379, [ 596.500 ], 7.076, True>      <- alert found <timestamp: pushid, [ value ], ttest result, alert T|F>
-  <1545607037: 417328, [ 626.500 ], 9.357, True>
-  opt:geomean
-  <1545319998: 416379, [ 380.380 ], 8.658, True>
-  <1545607037: 417328, [ 394.440 ], 8.364, True>
-  <1546034133: 418125, [ 453.630 ], 27.294, True>
-  pgo:ttfi
-  <1545599603: 417317, [ 593.000 ], 12.614, True>
-  pgo:loadtime
-  pgo:fnbpaint
-  <1545310832: 416336, [ 275.000 ], 7.970, True>
-  <1545607037: 417328, [ 283.500 ], 8.181, True>
-  pgo:hero:hero1
-  <1545330071: 416449, [ 677.000 ], 7.836, True>
-  pgo:dcf
-  <1545310832: 416336, [ 167.000 ], 8.328, True>
-  <1545599603: 417317, [ 170.000 ], 9.429, True>
-  pgo:geomean
-  <1545310832: 416336, [ 369.600 ], 9.036, True>
-  <1545599603: 417317, [ 372.170 ], 10.213, True>
-  <1546034133: 418125, [ 420.000 ], 19.099, True>
-  opt:fnbpaint
-  <1545319998: 416379, [ 289.500 ], 7.558, True>
-  opt:hero:hero1
-  <1545319998: 416379, [ 703.500 ], 8.397, True>
-  <1545607037: 417328, [ 739.000 ], 8.951, True>
-  opt:dcf
-  <1545319998: 416379, [ 172.000 ], 7.654, True>
-  opt:loadtime
+pipenv run python perfherder_alerts.py --framework raptor --branch mozilla-inbound --platform linux64 --platform windows7-32
+```
+
+Output:
+
+```
+-------- linux64 -------------                      <- <platform>
+raptor-tp6-wikia-firefox: pgo:geomean (1)           <- opt||pgo : <metric>
+2019-01-15T17:50:32 (423295)                        <- alert <timestamp> (<pushid>)
+
+raptor-tp6-wikia-firefox: opt:geomean (1)
+2019-01-18T09:19:57 (424516)
+
+raptor-tp6-sheets-firefox: opt:geomean (1)
+2018-12-28T21:55:33 (418125)
+
+-------- windows7-32 -------------
+raptor-tp6-wikia-firefox: opt:geomean (1)
+2018-12-23T23:17:17 (417328)
+
+raptor-tp6-wikia-firefox: pgo:geomean (1)
+2018-12-28T21:55:33 (418125)
+
+raptor-tp6-apple-firefox: opt:geomean (1)
+2019-01-18T10:32:47 (424533)
 ```
 
 you can see from this output that maybe pushids are common, one could assume that many of these alerts would be in the same alert summary.


### PR DESCRIPTION
Several changes, but the only notable new feature is the command line options for setting framework, branch, platform, and whether to include subtests. I've also introduced [pipenv](https://pipenv.readthedocs.io/en/latest/) so dependencies are locked, made the code compliant with [black](https://github.com/ambv/black) and [flake8](http://flake8.pycqa.org/en/latest/index.html).